### PR TITLE
Fix data-template namespace issues

### DIFF
--- a/rendering/rendering.js
+++ b/rendering/rendering.js
@@ -41,7 +41,7 @@
 			return template.fn(data, $.extend(filters, _defaultFilters))
 				.data('data', data)
 				.data('filters', filters)
-				.data('template', template)
+				.data('_renderingTemplate', template)
 				.addClass('rendered')
 				.removeAttr('data-template');
 		};
@@ -88,7 +88,7 @@
 				if (typeof data == 'undefined') {
 					data = $part.data('data');
 				}
-				var template = $part.data('template');
+				var template = $part.data('_renderingTemplate');
 				var filters = $part.data('filters');
 				var $new = _renderOne(template, data, filters);
 				template.placeholder.splice(template.placeholder.index($part.get(0)), 1, $new.get(0));


### PR DESCRIPTION
`data-template` is left in a rendered DOM element after being rendered in case
it needs to be refreshed later.  The only problem is that some other plug-ins
(namely Bootstrap's tooltip.js look for the data-template attribute when trying
to template out a related element (e.g. the tooltip).  I am not sure that this
commit is the best way to fix the problem as it is more of a bandage (simply
renaming the data attribute from `template` to `_renderingTemplate`.)  A better
solution might be to keep a private object of templates (keyed on the selector
or a unique id of the object) and not attaching it to the element's data object
directly.
